### PR TITLE
Ensure serializer doesn't include type ID comments

### DIFF
--- a/funktion-model/src/main/java/io/fabric8/funktion/support/YamlHelper.java
+++ b/funktion-model/src/main/java/io/fabric8/funktion/support/YamlHelper.java
@@ -29,6 +29,8 @@ public class YamlHelper {
         ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory()
                 .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
                 .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, true)
+                .configure(YAMLGenerator.Feature.USE_NATIVE_OBJECT_ID, false)
+                .configure(YAMLGenerator.Feature.USE_NATIVE_TYPE_ID, false)
         );
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY).
                 enable(SerializationFeature.INDENT_OUTPUT).


### PR DESCRIPTION
~~Otherwise when serializing a Funktion to YAML the kind was being left out :(~~

Problem was different... including native type IDs in YAML instead of serializing kind properly.